### PR TITLE
Avoid deceptive scope mismatch?

### DIFF
--- a/config/sources/call.nix
+++ b/config/sources/call.nix
@@ -1,10 +1,10 @@
 { file }: let
-  pkgs = import ../../external/nixpkgs {
+  fetchers = import ../../external/nixpkgs {
     overlays = [(self: super: {
       gitlabtoken = import ../../external/private/gitlabtoken;
       ethzgitlabtoken = import ../../external/private/ethzgitlabtoken;
     })];
   };
-in pkgs.callPackage file {} // {
+in fetchers.callPackage file {} // {
   inherit file;
 }


### PR DESCRIPTION
I was thinking quite a bit about this out of academic interest.

I even opened a question at discourse: https://discourse.nixos.org/t/deceptive-scope-mismatches/9239

This PR is the closest to a solution I could come.

What are your thoughts? &mdash; this is haunting me :wink: 

---

or even as follows, to stress it's largely arbitrary:
```
  fetchers = import <nixpkgs> { ... };
```